### PR TITLE
tune(train): 50-epoch run + milestone-only checkpointing

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,8 +34,11 @@ DROPOUT          = 0.1
 BATCH_SIZE       = 128
 LEARNING_RATE    = 1e-3
 WEIGHT_DECAY     = 1e-4
-NUM_EPOCHS       = 20
+NUM_EPOCHS       = 50
 SEED             = 42
+
+# Checkpointing — save every Nth epoch + final (avoids 50 × 286 MB disk bloat).
+SAVE_EVERY_N_EPOCHS = 10
 
 # Temperature for InfoNCE loss
 # Set to None to use learnable temperature (recommended)

--- a/notebooks/03_training.ipynb
+++ b/notebooks/03_training.ipynb
@@ -217,9 +217,9 @@
    "source": [
     "## 6. Train\n",
     "\n",
-    "20 epochs, AdamW lr=1e-3, wd=1e-4, batch=128, learnable temperature.\n",
+    "50 epochs, AdamW lr=1e-3, wd=1e-4, batch=128, learnable temperature. Checkpoints are saved every 10 epochs + final epoch (so 6 total: epoch 10, 20, 30, 40, 50) to keep disk usage under control.\n",
     "\n",
-    "**Sanity check while it runs:** epoch 1 loss should print near `log(128) ≈ 4.85` and drop below 2.0 by epoch 10. If it's stuck at 4.5+ after epoch 3, kill it — something's wrong with the data wiring."
+    "**Sanity check while it runs:** epoch 1 loss should print near `log(128) ≈ 4.85` and drop below 2.0 by epoch 10. By epoch 50 it should be around 1.7–1.9. If it's stuck at 4.5+ after epoch 3, kill it — something's wrong with the data wiring."
    ]
   },
   {
@@ -277,7 +277,7 @@
    "outputs": [],
    "source": [
     "!python scripts/build_gallery_index.py \\\n",
-    "    --checkpoint experiments/checkpoints/checkpoint_epoch20_learnable.pt"
+    "    --checkpoint experiments/checkpoints/checkpoint_epoch50_learnable.pt"
    ]
   },
   {
@@ -296,7 +296,7 @@
    "outputs": [],
    "source": [
     "!python scripts/evaluate.py \\\n",
-    "    --checkpoint experiments/checkpoints/checkpoint_epoch20_learnable.pt"
+    "    --checkpoint experiments/checkpoints/checkpoint_epoch50_learnable.pt"
    ]
   },
   {
@@ -319,7 +319,7 @@
     "os.makedirs(OUT, exist_ok=True)\n",
     "\n",
     "artefacts = [\n",
-    "    'experiments/checkpoints/checkpoint_epoch20_learnable.pt',\n",
+    "    'experiments/checkpoints/checkpoint_epoch50_learnable.pt',\n",
     "    'experiments/checkpoints/training_history.json',\n",
     "    'experiments/checkpoints/loss_curve.png',\n",
     "    'data/cached/gallery_embs.pt',\n",
@@ -359,18 +359,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/05_demo_and_visualization.ipynb
+++ b/notebooks/05_demo_and_visualization.ipynb
@@ -134,8 +134,8 @@
     "        os.symlink(src, dst)\n",
     "\n",
     "# Trained checkpoint.\n",
-    "ckpt_src = f'{DRIVE}/output/checkpoint_epoch20_learnable.pt'\n",
-    "ckpt_dst = 'experiments/checkpoints/checkpoint_epoch20_learnable.pt'\n",
+    "ckpt_src = f'{DRIVE}/output/checkpoint_epoch50_learnable.pt'\n",
+    "ckpt_dst = 'experiments/checkpoints/checkpoint_epoch50_learnable.pt'\n",
     "if not os.path.exists(ckpt_dst):\n",
     "    os.symlink(ckpt_src, ckpt_dst)\n",
     "\n",
@@ -149,7 +149,7 @@
     "# those specific files exist. Bypasses the listdir() problem.\n",
     "print('Wired symlinks:')\n",
     "!ls -l data/cached/gallery_embs.pt data/cached/gallery_ids.json\n",
-    "!ls -l experiments/checkpoints/checkpoint_epoch20_learnable.pt\n",
+    "!ls -l experiments/checkpoints/checkpoint_epoch50_learnable.pt\n",
     "\n",
     "ids = json.load(open('data/cached/gallery_ids.json'))\n",
     "print(f'\\nGallery has {len(ids):,} image IDs. Spot-checking 3 of them on disk:')\n",
@@ -185,7 +185,7 @@
     "\n",
     "vision = VisionEncoder().to(device)\n",
     "text   = TextEncoder().to(device)\n",
-    "ckpt = torch.load('experiments/checkpoints/checkpoint_epoch20_learnable.pt',\n",
+    "ckpt = torch.load('experiments/checkpoints/checkpoint_epoch50_learnable.pt',\n",
     "                  map_location=device, weights_only=False)\n",
     "vision.load_state_dict(ckpt['vision_encoder'])\n",
     "text.load_state_dict(ckpt['text_encoder'])\n",
@@ -229,7 +229,7 @@
    "outputs": [],
    "source": [
     "!python src/demo/app.py \\\n",
-    "    --checkpoint experiments/checkpoints/checkpoint_epoch20_learnable.pt \\\n",
+    "    --checkpoint experiments/checkpoints/checkpoint_epoch50_learnable.pt \\\n",
     "    --share"
    ]
   },
@@ -279,18 +279,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/src/train.py
+++ b/src/train.py
@@ -27,7 +27,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import (
     BATCH_SIZE, LEARNING_RATE, WEIGHT_DECAY, NUM_EPOCHS,
     SEED, TEMPERATURE, CHECKPOINTS_DIR, NUM_WORKERS, PIN_MEMORY,
-    CACHED_DIR, CAPTIONS_FILE, SPLITS_DIR, TEXT_MODEL_NAME, MAX_TOKEN_LENGTH
+    CACHED_DIR, CAPTIONS_FILE, SPLITS_DIR, TEXT_MODEL_NAME, MAX_TOKEN_LENGTH,
+    SAVE_EVERY_N_EPOCHS,
 )
 from src.encoders.vision_encoder import VisionEncoder
 from src.encoders.text_encoder import TextEncoder
@@ -213,10 +214,13 @@ def train(args):
         print(f"\n  Epoch {epoch+1:02d} | Train Loss: {avg_train_loss:.4f} | "
               f"Val Loss: {avg_val_loss:.4f} | τ: {criterion.temperature:.4f}\n")
 
-        # ── Save checkpoint every epoch ───────────────────────────────────────
-        tag = f"temp{args.temperature}" if args.temperature else "learnable"
-        save_checkpoint(epoch + 1, vision_enc, text_enc, optimizer,
-                        avg_val_loss, tag=tag)
+        # ── Save checkpoint every N epochs + final (keeps disk usage sane) ────
+        tag         = f"temp{args.temperature}" if args.temperature else "learnable"
+        is_milestone = (epoch + 1) % SAVE_EVERY_N_EPOCHS == 0
+        is_final     = (epoch + 1) == args.epochs
+        if is_milestone or is_final:
+            save_checkpoint(epoch + 1, vision_enc, text_enc, optimizer,
+                            avg_val_loss, tag=tag)
 
     # ── Save training history ─────────────────────────────────────────────────
     hist_path = os.path.join(CHECKPOINTS_DIR, "training_history.json")


### PR DESCRIPTION
## Summary
- Bumps `NUM_EPOCHS` from **20 → 50** in `config.py`
- Saves checkpoints **every 10 epochs + final** instead of every epoch (avoids 14 GB of `.pt` files on Colab disk)
- Updates both notebooks to reference `checkpoint_epoch50_learnable.pt`

## Why
The 20-epoch baseline plateaued in the final 5 epochs (val 2.14 → 2.09). Want to see how much more we can squeeze out of the existing architecture before touching anything bigger.

| Epoch | Train | Val |
|---|---|---|
| 15 | 2.111 | 2.137 |
| 20 | 2.018 | 2.094 |

**Realistic expectation:** maybe **+2–3 % R@1** going from 20 → 50 epochs. Bigger gains need architectural changes (cosine LR schedule, unfreezing top BERT layers, hard-negative mining), which are out of scope here.

## Disk-usage math
- 1 checkpoint = ~286 MB (dominated by frozen DistilBERT weights — known waste, separate cleanup)
- Old behaviour (50 saves): 50 × 286 MB = **14 GB** on Colab disk during training
- New behaviour (every 10 + final): 6 × 286 MB = **1.7 GB** ✓

## What stays the same
- `--resume <ckpt>` still works — pass any milestone (epoch 10, 20, 30, 40 or 50)
- `--temperature {0.05, 0.07, 0.10}` ablations unaffected (each gets its own tag in the filename)
- Demo, evaluate.py, and build_gallery_index.py work without changes — they just receive the final checkpoint by name

## Test plan
- [ ] Run [03_training.ipynb](../notebooks/03_training.ipynb) on Colab T4 → ~30 min for 50 epochs
- [ ] Verify only 6 checkpoint files remain after the run
- [ ] Re-run `scripts/evaluate.py --checkpoint experiments/checkpoints/checkpoint_epoch50_learnable.pt`
- [ ] Update `docs/RESULTS.md` and `docs/EXPERIMENTS.md` with the new numbers (separate PR after the run)
- [ ] Re-run `scripts/build_gallery_index.py` against the 50-epoch checkpoint, push the new `gallery_embs.pt` to Drive